### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP server enables Claude to interact with Webflow's APIs.
 
+<a href="https://glama.ai/mcp/servers/un9r0vtmku">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/un9r0vtmku/badge" alt="Webflow Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js (v16 or higher)


### PR DESCRIPTION
This PR adds a badge for the [Webflow MCP Server](https://glama.ai/mcp/servers/un9r0vtmku) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/un9r0vtmku">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/un9r0vtmku/badge" alt="Webflow Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.